### PR TITLE
Adding package.json and bower.json for dependency management

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "linea-scss",
+  "version": "1.0.0",
+  "homepage": "https://github.com/linea-io/linea-scss",
+  "authors": [
+    {"name": "Dario Ferrando", "homepage": "http://www.dario.io"},
+    {"name": "Benjamin Sigidi", "homepage": "https://github.com/benjaminsigidi"}
+  ],
+  "description": "SCSS version of Linea, a free outline iconset featuring 730+ icons.",
+  "main": "linea.scss",
+  "keywords": [
+    "linea",
+    "iconset",
+    "icons",
+    "fonts",
+    "icon",
+    "fonts",
+    "sass",
+    "compass",
+    "scss"
+  ],
+  "license": "CCBY",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "linea-scss",
+  "version": "1.0.0",
+  "description": "SCSS version of Linea, a free outline iconset featuring 730+ icons.",
+  "main": "linea.scss",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/linea-io/linea-scss.git"
+  },
+  "keywords": [
+    "icons",
+    "iconset",
+    "icon",
+    "font",
+    "scss",
+    "compass",
+    "sass"
+  ],
+  "contributors": [
+    {"name": "Dario Ferrando", "url": "http://www.dario.io"},
+    {"name": "Benjamin Sigidi", "url": "https://github.com/benjaminsigidi"}
+  ],
+  "license": "CCBY",
+  "bugs": {
+    "url": "https://github.com/linea-io/linea-scss/issues"
+  },
+  "homepage": "https://github.com/linea-io/linea-scss#readme"
+}


### PR DESCRIPTION
I really want to use these in my next project, but noticed the repo's lacking a `bower.json` and `package.json`, for Bower and NPM respectively. This PR adds lets them be managed by either of those, but you need to go to each and register the package ([Bower docs](http://bower.io/docs/creating-packages/#register) | [NPM docs](https://docs.npmjs.com/cli/publish)) so they can be installed via `bower install linea-scss` and `npm install linea-scss`.
